### PR TITLE
fix: correct constructor for `2022-blake3-chacha8-poly1305`

### DIFF
--- a/shadowaead_2022/method.go
+++ b/shadowaead_2022/method.go
@@ -90,13 +90,12 @@ func NewMethod(ctx context.Context, methodName string, options C.MethodOptions) 
 		}
 		m.keySaltLength = 32
 		m.constructor = chacha20poly1305.New
-		m.blockConstructor = aes.NewCipher
 	case "2022-blake3-chacha8-poly1305":
 		if len(m.pskList) > 1 {
 			return nil, ErrNoEIH
 		}
 		m.keySaltLength = 32
-		m.constructor = chacha.NewChaCha20IETFPoly1305
+		m.constructor = chacha.NewChaCha8IETFPoly1305
 	case "2022-blake3-aes-128-ccm":
 		m.keySaltLength = 16
 		m.constructor = aeadCipher(aes.NewCipher, func(cipher cipher.Block) (cipher.AEAD, error) { return ccm.NewCCM(cipher) })


### PR DESCRIPTION
I tested it, and for some unknown reason, communication with `shadowsocks-rust`'s `2022-blake3-chacha8-poly1305` is still not possible.

ps: It's working now.
https://github.com/MetaCubeX/chacha/commit/b3f4a9aea21617efd128f5cb0e148c7283fe5877